### PR TITLE
Fix Documentation Issue: Add Missing Heading and Enhance with Markdown Styling

### DIFF
--- a/notes/basic-commands.md
+++ b/notes/basic-commands.md
@@ -1,5 +1,4 @@
 # Basic commands
-
 Some base linux commands
 
 - pwd: Print working file
@@ -11,6 +10,8 @@ Some base linux commands
 
 - ls -R → List all the content of all the folders inside every folder
 - ls --t → Sort based onmodified time
+
+### Variations of cd command
 - `cd` → Change Directory to the home and give some parameters
 
 - `cd ../` or `cd ..` → Takes to the previous directory


### PR DESCRIPTION
Fixed missing heading for a specific command as mentioned in #17 


**Changes**
- Added a missing heading for the **`cd`** command.- Applied Markdown styling


