### PR TITLE
auto assign workflow

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,23 @@
+name: Assign
+on:
+  issue_comment:
+    types: created
+
+# Restrict the permissions granted to the use of secrets.GITHUB_TOKEN in this
+# github actions workflow:
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+permissions:
+  issues: write
+
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    # Note that string comparisons is not case sensitive.
+    if: >-
+       startsWith(github.event.comment.body, '/take')
+       && !github.event.issue.assignee
+    steps:
+      - run: |
+          echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/help%20wanted


### PR DESCRIPTION
This workflow get's triggered when there is comment starting with `/take` in any issue. If there is no one assigned to that issue it will be assigned to the one who commented this.

If this issue is successfully assigned to anyone then it removes label `help wanted` from issue